### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Jean-Yves VET
 maintainer=Jean-Yves VET <contact@jean-yves.vet>
 sentence=Library for SSD108 based monochrome 128x64 OLED screens.
 paragraph=Library for SSD108 based monochrome 128x64 OLED screens.
+category=Display
 url=.
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library OLED128x64 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format