### PR TITLE
Populate library.properties url field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Jean-Yves VET <contact@jean-yves.vet>
 sentence=Library for SSD108 based monochrome 128x64 OLED screens.
 paragraph=Library for SSD108 based monochrome 128x64 OLED screens.
 category=Display
-url=.
+url=https://github.com/jyvet/OLED128x64
 architectures=*


### PR DESCRIPTION
A empty/invalid url field results in an apparently clickable "More info" link in Library Manager that does nothing.